### PR TITLE
Fix syslog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ enable_language(CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
+include(CheckIncludeFiles)
+
 # --- Add-on Dependencies ------------------------------------------------------
 
 find_package(kodi REQUIRED)
@@ -26,9 +28,14 @@ set(JOYSTICK_SOURCES src/addon.cpp
                      src/JoystickTranslator.cpp
                      src/log/Log.cpp
                      src/log/LogAddon.cpp
-                     src/log/LogConsole.cpp
-                     src/log/LogSyslog.cpp)
+                     src/log/LogConsole.cpp)
 
+check_include_files("syslog.h" HAVE_SYSLOG)
+
+if(HAVE_SYSLOG)
+  list(APPEND JOYSTICK_SOURCES src/log/LogSyslog.cpp)
+endif()
+                               
 list(APPEND DEPLIBS ${kodiplatform_LIBRARIES})
 
 # --- Cocoa --------------------------------------------------------------------
@@ -61,7 +68,6 @@ endif()
 
 # --- Linux Joystick API -------------------------------------------------------
 
-include(CheckIncludeFiles)
 check_include_files(linux/joystick.h HAVE_LINUX_JOYSTICK_H)
 
 if(HAVE_LINUX_JOYSTICK_H)

--- a/src/log/Log.cpp
+++ b/src/log/Log.cpp
@@ -22,7 +22,10 @@
 #include "Log.h"
 #include "LogAddon.h"
 #include "LogConsole.h"
+
+#if defined(HAVE_SYSLOG)
 #include "LogSyslog.h"
+#endif
 
 #include "kodi/threads/threads.h"
 


### PR DESCRIPTION
I dont know much of the underlying build system and im also no expert on cmake so bear with me :)

Win doesn't have a syslog.h and i couldn't find one in msys so i had to disable these parts in the build for win. Interestingly enough there was already a check for HAVE_SYSLOG in Log.cpp but i couldn't find it being defined so i added a check in cmake and disabled the corresponding files.

ps: I didnt know if i should push here or to garbears repo. This here was more up to date so im pushing here.
ps2: Why exactly are you using a custom logging mechanism and not the kodi logging facilities?