### PR TITLE
Add missing constructor implemention.

### DIFF
--- a/src/api/linux/JoystickInterfaceLinux.h
+++ b/src/api/linux/JoystickInterfaceLinux.h
@@ -29,7 +29,7 @@ namespace JOYSTICK
   class CJoystickInterfaceLinux : public IJoystickInterface
   {
   public:
-    CJoystickInterfaceLinux(void);
+    CJoystickInterfaceLinux(void) { }
     virtual ~CJoystickInterfaceLinux(void) { }
 
     // implementation of IJoystickInterface


### PR DESCRIPTION
This should solve issue #6, which was missing a constructor implementation and crashing on load. 