### PR TITLE
CAnomalousTriggerFilter: the state is alos known if the center position is 0

### DIFF
--- a/src/api/AnomalousTriggerFilter.cpp
+++ b/src/api/AnomalousTriggerFilter.cpp
@@ -47,9 +47,8 @@ float CAnomalousTriggerFilter::Filter(float value)
 
       if (IsAnomalousTrigger())
         dsyslog("Anomalous trigger detected on axis %u (initial value = %f)", axisIndex, value);
-
-      m_state = STATE_CENTER_KNOWN;
     }
+    m_state = STATE_CENTER_KNOWN;
   }
 
   if (IsAnomalousTrigger())


### PR DESCRIPTION
I'm not 100% sure if this is correct or not but using a bluetooth controller on my windows 7 dev machine over DirectInput the `CAnomalousTriggerFilter` instances for the available axes isn't initialized (i.e. `m_state` is `STATE_IDLE` because `value` is always `0`) until the first axis movement and then `m_center` is determined based on the position that I moved the axis to which obviously results in a wrong calibration and all following axis movements are not correctly handled.