### PR TITLE
[directinput] remember GUID and read vendor/product ID

### DIFF
--- a/src/api/directinput/JoystickInterfaceDirectInput.h
+++ b/src/api/directinput/JoystickInterfaceDirectInput.h
@@ -24,6 +24,7 @@
 #define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
 
+#include <set>
 #include <vector>
 
 namespace JOYSTICK
@@ -31,7 +32,7 @@ namespace JOYSTICK
   class CJoystickInterfaceDirectInput : public CJoystickInterfaceCallback
   {
   public:
-    CJoystickInterfaceDirectInput(void) { }
+    CJoystickInterfaceDirectInput(void);
     virtual ~CJoystickInterfaceDirectInput(void) { Deinitialize(); }
 
     // implementation of IJoystickInterface
@@ -43,9 +44,11 @@ namespace JOYSTICK
   private:
     static BOOL CALLBACK EnumJoysticksCallback(const DIDEVICEINSTANCE *pdidInstance, VOID *pContext);
     static bool IsXInputDevice(const GUID *pGuidProductFromDirectInput); // TODO: Move to XInput
-    static HWND GetMainWindowHandle(void);
+    static std::set<HWND> GetMainWindowHandles(void);
     static BOOL CALLBACK EnumWindowsCallback(HWND hnd, LPARAM lParam);
 
+    HWND                    m_hWnd;         // Main window
     LPDIRECTINPUT8          m_pDirectInput; // DirectInput handle, we hold onto it and release it when freeing resources
+    bool                    m_bInitialized; // Whether DirectInput has been initialized or not
   };
 }


### PR DESCRIPTION
The first commit adds a member to `CJoystickDirectInput` to store the GUID of the represented joystick.
The second commit adds logic to read and remember the vendor/product ID of the joystick. I couldn't fully test this because I only have a bluetooth controller which appears as a generic windows bluetooth device and doesn't seem to have a proper vendor/product ID set (i.e. it returns 0).