### PR TITLE
Fix equality comparison of classes derived from CJoystick 

### DIFF
--- a/src/api/directinput/JoystickDirectInput.cpp
+++ b/src/api/directinput/JoystickDirectInput.cpp
@@ -45,6 +45,18 @@ CJoystickDirectInput::CJoystickDirectInput(GUID                           device
   SetName(strName);
 }
 
+bool CJoystickDirectInput::Equals(const CJoystick* rhs) const
+{
+  if (rhs == nullptr)
+    return false;
+
+  const CJoystickDirectInput* rhsDirectInput = dynamic_cast<const CJoystickDirectInput*>(rhs);
+  if (rhsDirectInput == nullptr)
+    return false;
+
+  return m_deviceGuid == rhsDirectInput->m_deviceGuid;
+}
+
 bool CJoystickDirectInput::Initialize(void)
 {
   HRESULT hr;

--- a/src/api/directinput/JoystickDirectInput.cpp
+++ b/src/api/directinput/JoystickDirectInput.cpp
@@ -34,10 +34,12 @@ using namespace JOYSTICK;
 #define JOY_POV_SW   (JOY_POVBACKWARD + JOY_POVLEFT) / 2
 #define JOY_POV_NW   (JOY_POVLEFT + JOY_POV_360) / 2
 
-CJoystickDirectInput::CJoystickDirectInput(LPDIRECTINPUTDEVICE8           joystickDevice,
+CJoystickDirectInput::CJoystickDirectInput(GUID                           deviceGuid,
+                                           LPDIRECTINPUTDEVICE8           joystickDevice,
                                            const std::string&             strName,
                                            CJoystickInterfaceDirectInput* api)
  : CJoystick(api),
+   m_deviceGuid(deviceGuid),
    m_joystickDevice(joystickDevice)
 {
   SetName(strName);

--- a/src/api/directinput/JoystickDirectInput.h
+++ b/src/api/directinput/JoystickDirectInput.h
@@ -31,7 +31,8 @@ namespace JOYSTICK
   class CJoystickDirectInput : public CJoystick
   {
   public:
-    CJoystickDirectInput(LPDIRECTINPUTDEVICE8           joystickDevice,
+    CJoystickDirectInput(GUID                           deviceGuid,
+                         LPDIRECTINPUTDEVICE8           joystickDevice,
                          const std::string&             strName,
                          CJoystickInterfaceDirectInput* api);
 
@@ -45,6 +46,7 @@ namespace JOYSTICK
   private:
     static BOOL CALLBACK EnumObjectsCallback(const DIDEVICEOBJECTINSTANCE *pdidoi, VOID *pContext);
 
+    GUID m_deviceGuid;
     LPDIRECTINPUTDEVICE8 m_joystickDevice;
   };
 }

--- a/src/api/directinput/JoystickDirectInput.h
+++ b/src/api/directinput/JoystickDirectInput.h
@@ -38,6 +38,8 @@ namespace JOYSTICK
 
     virtual ~CJoystickDirectInput(void) { }
 
+    virtual bool Equals(const CJoystick* rhs) const;
+
     virtual bool Initialize(void);
 
   protected:

--- a/src/api/directinput/JoystickInterfaceDirectInput.cpp
+++ b/src/api/directinput/JoystickInterfaceDirectInput.cpp
@@ -132,7 +132,7 @@ BOOL CALLBACK CJoystickInterfaceDirectInput::EnumJoysticksCallback(const DIDEVIC
 
   const std::string strName = pdidInstance->tszProductName ? pdidInstance->tszProductName : "";
 
-  context->AddScanResult(new CJoystickDirectInput(pJoystick, strName, context));
+  context->AddScanResult(new CJoystickDirectInput(pdidInstance->guidInstance, pJoystick, strName, context));
 
   return DIENUM_CONTINUE;
 }

--- a/src/api/xinput/JoystickXInput.cpp
+++ b/src/api/xinput/JoystickXInput.cpp
@@ -46,6 +46,18 @@ CJoystickXInput::CJoystickXInput(unsigned int controllerID, CJoystickInterfaceXI
   SetAxisCount(AXIS_COUNT);
 }
 
+bool CJoystickXInput::Equals(const CJoystick* rhs) const
+{
+  if (rhs == nullptr)
+    return false;
+
+  const CJoystickXInput* rhsXInput = dynamic_cast<const CJoystickXInput*>(rhs);
+  if (rhsXInput == nullptr)
+    return false;
+
+  return m_controllerID == rhsXInput->m_controllerID;
+}
+
 bool CJoystickXInput::ScanEvents(void)
 {
   XINPUT_STATE_EX controllerState;

--- a/src/api/xinput/JoystickXInput.h
+++ b/src/api/xinput/JoystickXInput.h
@@ -33,6 +33,8 @@ namespace JOYSTICK
     CJoystickXInput(unsigned int controllerID, CJoystickInterfaceXInput* api);
     virtual ~CJoystickXInput(void) { }
 
+    virtual bool Equals(const CJoystick* rhs) const;
+
   protected:
     virtual bool ScanEvents(void);
 


### PR DESCRIPTION
This fixes the equality comparison for `CJoystickDirectInput` and `CJoystickXInput`. The problem is that comparing an initialized `CJoystick` object with an uninitialized one (as it is done when checking if a discovered joystick is already known) will always fail because the initialization alters the properties used in the comparison.

For `CJoystickDirectInput` we remember the GUID of the DirectInput device and use that one for the equality comparison.
For `CJoystickXInput` we simply compare the controller index (which is always a value between `0` and `3`).