### PR TITLE
[buttonmap] Add XBox 360 Wireless and Logitech RumblePad 2 for Linux

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Logitech_Logitech_RumblePad_2_USB_12b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Logitech_Logitech_RumblePad_2_USB_12b_6a.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Logitech Logitech RumblePad 2 USB" provider="linux" buttoncount="12" axiscount="6">
+        <controller id="game.controller.default">
+            <feature name="a" button="1" />
+            <feature name="b" button="2" />
+            <feature name="back" button="8" />
+            <feature name="down" axis="+5" />
+            <feature name="left" axis="-4" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <right axis="+0" />
+            </feature>
+            <feature name="leftthumb" button="10" />
+            <feature name="lefttrigger" button="6" />
+            <feature name="right" axis="+4" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-3" />
+                <right axis="+2" />
+            </feature>
+            <feature name="rightthumb" button="11" />
+            <feature name="righttrigger" button="7" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-5" />
+            <feature name="x" button="0" />
+            <feature name="y" button="3" />
+        </controller>
+        <controller id="game.controller.gba">
+            <feature name="a" button="1" />
+            <feature name="b" button="0" />
+            <feature name="down" axis="+5" />
+            <feature name="left" axis="-4" />
+            <feature name="leftbumper" button="4" />
+            <feature name="right" axis="+4" />
+            <feature name="rightbumper" button="5" />
+            <feature name="select" button="8" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-5" />
+        </controller>
+        <controller id="game.controller.genesis">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="c" button="2" />
+            <feature name="down" axis="+5" />
+            <feature name="left" axis="-4" />
+            <feature name="mode" button="8" />
+            <feature name="right" axis="+4" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-5" />
+            <feature name="x" button="4" />
+            <feature name="y" button="3" />
+            <feature name="z" button="5" />
+        </controller>
+        <controller id="game.controller.n64">
+            <feature name="a" button="1" />
+            <feature name="analogstick">
+                <up axis="-1" />
+                <right axis="+0" />
+            </feature>
+            <feature name="b" button="0" />
+            <feature name="cdown" axis="+3" />
+            <feature name="cleft" axis="-2" />
+            <feature name="cright" axis="+2" />
+            <feature name="cup" axis="-3" />
+            <feature name="down" axis="+5" />
+            <feature name="left" axis="-4" />
+            <feature name="leftbumper" button="4" />
+            <feature name="right" axis="+4" />
+            <feature name="rightbumper" button="5" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-5" />
+            <feature name="z" button="6" />
+        </controller>
+        <controller id="game.controller.nes">
+            <feature name="a" button="1" />
+            <feature name="b" button="0" />
+            <feature name="down" axis="+5" />
+            <feature name="left" axis="-4" />
+            <feature name="right" axis="+4" />
+            <feature name="select" button="8" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-5" />
+        </controller>
+        <controller id="game.controller.ps">
+            <feature name="circle" button="2" />
+            <feature name="cross" button="1" />
+            <feature name="down" axis="+5" />
+            <feature name="left" axis="-4" />
+            <feature name="leftbumper" button="4" />
+            <feature name="lefttrigger" button="6" />
+            <feature name="right" axis="+4" />
+            <feature name="rightbumper" button="5" />
+            <feature name="righttrigger" button="7" />
+            <feature name="select" button="8" />
+            <feature name="square" button="0" />
+            <feature name="start" button="9" />
+            <feature name="triangle" button="3" />
+            <feature name="up" axis="-5" />
+        </controller>
+        <controller id="game.controller.snes">
+            <feature name="a" button="2" />
+            <feature name="b" button="1" />
+            <feature name="down" axis="+5" />
+            <feature name="left" axis="-4" />
+            <feature name="leftbumper" button="4" />
+            <feature name="right" axis="+4" />
+            <feature name="rightbumper" button="5" />
+            <feature name="select" button="8" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-5" />
+            <feature name="x" button="3" />
+            <feature name="y" button="0" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_360_Wireless_Receiver_15b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_360_Wireless_Receiver_15b_6a.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Xbox 360 Wireless Receiver" provider="linux" buttoncount="15" axiscount="6">
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="6" />
+            <feature name="down" button="14" />
+            <feature name="guide" button="8" />
+            <feature name="left" button="11" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <right axis="+0" />
+            </feature>
+            <feature name="leftthumb" button="9" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" button="12" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <right axis="+3" />
+            </feature>
+            <feature name="rightthumb" button="10" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="7" />
+            <feature name="up" button="13" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+        <controller id="game.controller.gba">
+            <feature name="a" button="0" />
+            <feature name="b" button="2" />
+            <feature name="down" button="14" />
+            <feature name="left" button="11" />
+            <feature name="leftbumper" button="4" />
+            <feature name="right" button="12" />
+            <feature name="rightbumper" button="5" />
+            <feature name="select" button="6" />
+            <feature name="start" button="7" />
+            <feature name="up" button="13" />
+        </controller>
+        <controller id="game.controller.genesis">
+            <feature name="a" button="2" />
+            <feature name="b" button="0" />
+            <feature name="c" button="1" />
+            <feature name="down" button="14" />
+            <feature name="left" button="11" />
+            <feature name="mode" button="6" />
+            <feature name="right" button="12" />
+            <feature name="start" button="7" />
+            <feature name="up" button="13" />
+            <feature name="x" button="4" />
+            <feature name="y" button="3" />
+            <feature name="z" button="5" />
+        </controller>
+        <controller id="game.controller.n64">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="cdown" axis="+4" />
+            <feature name="cleft" axis="-3" />
+            <feature name="cright" axis="+3" />
+            <feature name="cup" axis="-4" />
+            <feature name="down" button="14" />
+            <feature name="left" button="11" />
+            <feature name="leftbumper" button="4" />
+            <feature name="right" button="12" />
+            <feature name="rightbumper" button="5" />
+            <feature name="start" button="7" />
+            <feature name="up" button="13" />
+        </controller>
+        <controller id="game.controller.nes">
+            <feature name="a" button="0" />
+            <feature name="b" button="2" />
+            <feature name="down" button="14" />
+            <feature name="left" button="11" />
+            <feature name="right" button="12" />
+            <feature name="select" button="6" />
+            <feature name="start" button="7" />
+            <feature name="up" button="13" />
+        </controller>
+        <controller id="game.controller.ps">
+            <feature name="circle" button="1" />
+            <feature name="cross" button="0" />
+            <feature name="down" button="14" />
+            <feature name="left" button="11" />
+            <feature name="leftbumper" button="4" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" button="12" />
+            <feature name="rightbumper" button="5" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="select" button="6" />
+            <feature name="square" button="2" />
+            <feature name="start" button="7" />
+            <feature name="triangle" button="3" />
+            <feature name="up" button="13" />
+        </controller>
+        <controller id="game.controller.snes">
+            <feature name="a" button="1" />
+            <feature name="b" button="0" />
+            <feature name="down" button="14" />
+            <feature name="left" button="11" />
+            <feature name="leftbumper" button="4" />
+            <feature name="right" button="12" />
+            <feature name="rightbumper" button="5" />
+            <feature name="select" button="6" />
+            <feature name="start" button="7" />
+            <feature name="up" button="13" />
+            <feature name="x" button="3" />
+            <feature name="y" button="2" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
Here are 2 button maps for Linux for the controllers I own.
They should be fairly close to the button positions on the respective original controllers (even if they have buttons with the same label but on a different position. For example on (A, B) on SNES are (B, A) on XBox 360.