### PR TITLE
RFC: [joystick] Remove Bluetooth MAC address from device name

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/linux/PLAYSTATION_R_3_Controller_17b_29a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/PLAYSTATION_R_3_Controller_17b_29a.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="PLAYSTATION(R)3 Controller" provider="linux" buttoncount="17" axiscount="29">
+        <controller id="game.controller.default">
+            <feature name="a" button="14" />
+            <feature name="b" button="13" />
+            <feature name="back" button="0" />
+            <feature name="down" button="6" />
+            <feature name="guide" button="16" />
+            <feature name="left" button="7" />
+            <feature name="leftbumper" button="10" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <right axis="+0" />
+            </feature>
+            <feature name="leftthumb" button="1" />
+            <feature name="lefttrigger" button="8" />
+            <feature name="right" button="5" />
+            <feature name="rightbumper" button="11" />
+            <feature name="rightstick">
+                <up axis="-3" />
+                <right axis="+2" />
+            </feature>
+            <feature name="rightthumb" button="2" />
+            <feature name="righttrigger" button="9" />
+            <feature name="start" button="3" />
+            <feature name="up" button="4" />
+            <feature name="x" button="15" />
+            <feature name="y" button="12" />
+        </controller>
+        <controller id="game.controller.gba">
+            <feature name="a" button="14" />
+            <feature name="b" button="15" />
+            <feature name="down" button="6" />
+            <feature name="left" button="7" />
+            <feature name="leftbumper" button="10" />
+            <feature name="right" button="5" />
+            <feature name="rightbumper" button="11" />
+            <feature name="select" button="0" />
+            <feature name="start" button="3" />
+            <feature name="up" button="4" />
+        </controller>
+        <controller id="game.controller.genesis">
+            <feature name="a" button="15" />
+            <feature name="b" button="14" />
+            <feature name="c" button="13" />
+            <feature name="down" button="14" />
+            <feature name="left" button="11" />
+            <feature name="mode" button="0" />
+            <feature name="right" button="12" />
+            <feature name="start" button="3" />
+            <feature name="up" button="13" />
+            <feature name="x" button="10" />
+            <feature name="y" button="12" />
+            <feature name="z" button="11" />
+        </controller>
+        <controller id="game.controller.n64">
+            <feature name="a" button="14" />
+            <feature name="b" button="15" />
+            <feature name="cdown" axis="+3" />
+            <feature name="cleft" axis="-2" />
+            <feature name="cright" axis="+2" />
+            <feature name="cup" axis="-3" />
+            <feature name="down" button="6" />
+            <feature name="left" button="7" />
+            <feature name="leftbumper" button="10" />
+            <feature name="right" button="5" />
+            <feature name="rightbumper" button="11" />
+            <feature name="start" button="3" />
+            <feature name="up" button="4" />
+            <feature name="z" button="8" />
+        </controller>
+        <controller id="game.controller.nes">
+            <feature name="a" button="14" />
+            <feature name="b" button="15" />
+            <feature name="down" button="6" />
+            <feature name="left" button="7" />
+            <feature name="right" button="5" />
+            <feature name="select" button="0" />
+            <feature name="start" button="3" />
+            <feature name="up" button="4" />
+        </controller>
+        <controller id="game.controller.ps">
+            <feature name="circle" button="13" />
+            <feature name="cross" button="14" />
+            <feature name="down" button="6" />
+            <feature name="left" button="7" />
+            <feature name="leftbumper" button="10" />
+            <feature name="lefttrigger" button="8" />
+            <feature name="right" button="5" />
+            <feature name="rightbumper" button="11" />
+            <feature name="righttrigger" button="9" />
+            <feature name="select" button="0" />
+            <feature name="square" button="15" />
+            <feature name="start" button="3" />
+            <feature name="triangle" button="12" />
+            <feature name="up" button="4" />
+        </controller>
+        <controller id="game.controller.snes">
+            <feature name="a" button="13" />
+            <feature name="b" button="14" />
+            <feature name="down" button="6" />
+            <feature name="left" button="7" />
+            <feature name="leftbumper" button="10" />
+            <feature name="right" button="5" />
+            <feature name="rightbumper" button="11" />
+            <feature name="select" button="0" />
+            <feature name="start" button="3" />
+            <feature name="up" button="4" />
+            <feature name="x" button="12" />
+            <feature name="y" button="15" />
+        </controller>
+    </device>
+</buttonmap>

--- a/src/api/Joystick.cpp
+++ b/src/api/Joystick.cpp
@@ -57,6 +57,9 @@ void CJoystick::SetName(const std::string& strName)
 {
   std::string strSanitizedFilename(strName);
 
+  // Remove Bluetooth MAC address as seen in Sony Playstation controllers
+  StringUtils::RemoveMACAddress(strSanitizedFilename);
+
   StringUtils::Trim(strSanitizedFilename);
 
   ADDON::Joystick::SetName(strSanitizedFilename);

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <cctype>
 #include <functional>
+#include <regex>
 
 using namespace JOYSTICK;
 
@@ -60,6 +61,12 @@ std::string StringUtils::MakeSafeUrl(const std::string& str)
     });
 
   return safeUrl;
+}
+
+std::string& StringUtils::RemoveMACAddress(std::string& str)
+{
+  std::regex mac("[\\(\\[]?([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})[\\)\\]]?");
+  str = std::regex_replace(str, mac, "");
 }
 
 std::string& StringUtils::Trim(std::string& str)

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -40,6 +40,13 @@ namespace JOYSTICK
      */
     static std::string MakeSafeUrl(const std::string& str);
 
+    /*!
+     * \brief Removes a MAC address from a given string
+     * \param str The string containing a MAC address
+     * \return The string without the MAC address (for chaining)
+     */
+    static std::string& RemoveMACAddress(std::string& str);
+
     static std::string& Trim(std::string& str);
     static std::string& TrimLeft(std::string& str);
     static std::string& TrimRight(std::string& str);


### PR DESCRIPTION
Hi @garbear: I'll push 2 PRs that allow to use Sony PS3 (Sixaxis) controllers connected via Bluetooth. These controllers have their own Bluetooth MAC address in the device name, which makes it impossible to share buttonmaps with others. Hence I'm using a regular expression to remove it from the device name.

This version (PR1) uses the regex module of C++11. I haven't found any documentation about current minimum compiler versions for Kodi. On Linux this would require GCC 4.9. Not sure about Windows or OS X.
The advantage is obviously that it doesn't have any external dependencies. But I'll push a second PR with PCRE in a moment.