### PR TITLE
[buttonmap] Add Sony PS3 map (connected through Bluez 5)

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/linux/PLAYSTATION_R_3_Controller.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/PLAYSTATION_R_3_Controller.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <!-- Sony Playstation 3 Controller connected through the Bluez 5 sixaxis plugin. -->
+    <device name="PLAYSTATION(R)3 Controller" provider="linux" buttoncount="19" axiscount="27">
+        <controller id="game.controller.default">
+            <feature name="a" button="14" />
+            <feature name="b" button="13" />
+            <feature name="back" button="0" />
+            <feature name="down" button="6" />
+            <feature name="guide" button="16" />
+            <feature name="left" button="7" />
+            <feature name="leftbumper" button="10" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <right axis="+0" />
+            </feature>
+            <feature name="leftthumb" button="1" />
+            <feature name="lefttrigger" button="8" />
+            <feature name="right" button="5" />
+            <feature name="rightbumper" button="11" />
+            <feature name="rightstick">
+                <up axis="-3" />
+                <right axis="+2" />
+            </feature>
+            <feature name="rightthumb" button="2" />
+            <feature name="righttrigger" button="9" />
+            <feature name="start" button="3" />
+            <feature name="up" button="4" />
+            <feature name="x" button="15" />
+            <feature name="y" button="12" />
+        </controller>
+        <controller id="game.controller.gba">
+            <feature name="a" button="14" />
+            <feature name="b" button="15" />
+            <feature name="down" button="6" />
+            <feature name="left" button="7" />
+            <feature name="leftbumper" button="10" />
+            <feature name="right" button="5" />
+            <feature name="rightbumper" button="11" />
+            <feature name="select" button="0" />
+            <feature name="start" button="3" />
+            <feature name="up" button="4" />
+        </controller>
+        <controller id="game.controller.genesis">
+            <feature name="a" button="15" />
+            <feature name="b" button="14" />
+            <feature name="c" button="13" />
+            <feature name="down" button="14" />
+            <feature name="left" button="11" />
+            <feature name="mode" button="0" />
+            <feature name="right" button="12" />
+            <feature name="start" button="3" />
+            <feature name="up" button="13" />
+            <feature name="x" button="10" />
+            <feature name="y" button="12" />
+            <feature name="z" button="11" />
+        </controller>
+        <controller id="game.controller.n64">
+            <feature name="a" button="14" />
+            <feature name="b" button="15" />
+            <feature name="cdown" axis="+3" />
+            <feature name="cleft" axis="-2" />
+            <feature name="cright" axis="+2" />
+            <feature name="cup" axis="-3" />
+            <feature name="down" button="6" />
+            <feature name="left" button="7" />
+            <feature name="leftbumper" button="10" />
+            <feature name="right" button="5" />
+            <feature name="rightbumper" button="11" />
+            <feature name="start" button="3" />
+            <feature name="up" button="4" />
+            <feature name="z" button="8" />
+        </controller>
+        <controller id="game.controller.nes">
+            <feature name="a" button="14" />
+            <feature name="b" button="15" />
+            <feature name="down" button="6" />
+            <feature name="left" button="7" />
+            <feature name="right" button="5" />
+            <feature name="select" button="0" />
+            <feature name="start" button="3" />
+            <feature name="up" button="4" />
+        </controller>
+        <controller id="game.controller.ps">
+            <feature name="circle" button="13" />
+            <feature name="cross" button="14" />
+            <feature name="down" button="6" />
+            <feature name="left" button="7" />
+            <feature name="leftbumper" button="10" />
+            <feature name="lefttrigger" button="8" />
+            <feature name="right" button="5" />
+            <feature name="rightbumper" button="11" />
+            <feature name="righttrigger" button="9" />
+            <feature name="select" button="0" />
+            <feature name="square" button="15" />
+            <feature name="start" button="3" />
+            <feature name="triangle" button="12" />
+            <feature name="up" button="4" />
+        </controller>
+        <controller id="game.controller.snes">
+            <feature name="a" button="13" />
+            <feature name="b" button="14" />
+            <feature name="down" button="6" />
+            <feature name="left" button="7" />
+            <feature name="leftbumper" button="10" />
+            <feature name="right" button="5" />
+            <feature name="rightbumper" button="11" />
+            <feature name="select" button="0" />
+            <feature name="start" button="3" />
+            <feature name="up" button="4" />
+            <feature name="x" button="12" />
+            <feature name="y" button="15" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
Adds a buttonmap for Sony Playstation 3 controllers for Linux which is used when the controller is connected through Bluetooth with the sixaxis plugin in Bluez 5. With this buttonmap the controller works
out of the box in OpenELEC 6 (RetroPlayer test builds).