### PR TITLE
sync with platform rename to p8-platform Pulse-Eight/platform#20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(CheckIncludeFiles)
 
 find_package(kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
-find_package(platform REQUIRED)
+find_package(p8-platform REQUIRED)
 find_package(PCRE REQUIRED)
 
 include_directories(${INCLUDES}

--- a/src/api/Joystick.cpp
+++ b/src/api/Joystick.cpp
@@ -24,14 +24,14 @@
 #include "utils/CommonMacros.h"
 #include "utils/StringUtils.h"
 
-#include "platform/util/timeutils.h"
+#include "p8-platform/util/timeutils.h"
 
 using namespace JOYSTICK;
 
 #define ANALOG_EPSILON  0.0001f
 
 CJoystick::CJoystick(const std::string& strProvider)
- : m_discoverTimeMs(PLATFORM::GetTimeMs()),
+ : m_discoverTimeMs(P8PLATFORM::GetTimeMs()),
    m_activateTimeMs(-1),
    m_firstEventTimeMs(-1),
    m_lastEventTimeMs(-1)
@@ -161,7 +161,7 @@ void CJoystick::GetAxisEvents(std::vector<ADDON::PeripheralEvent>& events)
 void CJoystick::SetButtonValue(unsigned int buttonIndex, JOYSTICK_STATE_BUTTON buttonValue)
 {
   if (m_activateTimeMs < 0)
-    m_activateTimeMs = PLATFORM::GetTimeMs();
+    m_activateTimeMs = P8PLATFORM::GetTimeMs();
 
   if (buttonIndex < ButtonCount())
     m_stateBuffer.buttons[buttonIndex] = buttonValue;
@@ -170,7 +170,7 @@ void CJoystick::SetButtonValue(unsigned int buttonIndex, JOYSTICK_STATE_BUTTON b
 void CJoystick::SetHatValue(unsigned int hatIndex, JOYSTICK_STATE_HAT hatValue)
 {
   if (m_activateTimeMs < 0)
-    m_activateTimeMs = PLATFORM::GetTimeMs();
+    m_activateTimeMs = P8PLATFORM::GetTimeMs();
 
   if (hatIndex < HatCount())
     m_stateBuffer.hats[hatIndex] = hatValue;
@@ -179,7 +179,7 @@ void CJoystick::SetHatValue(unsigned int hatIndex, JOYSTICK_STATE_HAT hatValue)
 void CJoystick::SetAxisValue(unsigned int axisIndex, JOYSTICK_STATE_AXIS axisValue)
 {
   if (m_activateTimeMs < 0)
-    m_activateTimeMs = PLATFORM::GetTimeMs();
+    m_activateTimeMs = P8PLATFORM::GetTimeMs();
 
   axisValue = CONSTRAIN(-1.0f, axisValue, 1.0f);
 
@@ -195,8 +195,8 @@ void CJoystick::SetAxisValue(unsigned int axisIndex, long value, long maxAxisAmo
 void CJoystick::UpdateTimers(void)
 {
   if (m_firstEventTimeMs < 0)
-    m_firstEventTimeMs = PLATFORM::GetTimeMs();
-  m_lastEventTimeMs = PLATFORM::GetTimeMs();
+    m_firstEventTimeMs = P8PLATFORM::GetTimeMs();
+  m_lastEventTimeMs = P8PLATFORM::GetTimeMs();
 }
 
 float CJoystick::NormalizeAxis(long value, long maxAxisAmount)

--- a/src/api/JoystickAsync.cpp
+++ b/src/api/JoystickAsync.cpp
@@ -20,7 +20,7 @@
 #include "JoystickAsync.h"
 
 using namespace JOYSTICK;
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 
 CJoystickAsync::CJoystickAsync(const std::string& strProvider)
   : CJoystick(strProvider)

--- a/src/api/JoystickAsync.h
+++ b/src/api/JoystickAsync.h
@@ -20,7 +20,7 @@
 
 #include "Joystick.h"
 
-#include "platform/threads/mutex.h"
+#include "p8-platform/threads/mutex.h"
 
 namespace JOYSTICK
 {
@@ -45,6 +45,6 @@ namespace JOYSTICK
     virtual void SetAxisValue(unsigned int axisIndex, JOYSTICK_STATE_AXIS axisValue) override;
 
   private:
-    PLATFORM::CMutex m_mutex;
+    P8PLATFORM::CMutex m_mutex;
   };
 }

--- a/src/api/JoystickManager.cpp
+++ b/src/api/JoystickManager.cpp
@@ -43,7 +43,7 @@
 #include <algorithm>
 
 using namespace JOYSTICK;
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 
 // --- Utility functions -------------------------------------------------------
 

--- a/src/api/JoystickManager.h
+++ b/src/api/JoystickManager.h
@@ -22,7 +22,7 @@
 #include "JoystickTypes.h"
 
 #include "kodi/kodi_peripheral_utils.hpp"
-#include "platform/threads/mutex.h"
+#include "p8-platform/threads/mutex.h"
 
 #include <vector>
 
@@ -88,7 +88,7 @@ namespace JOYSTICK
     std::vector<IJoystickInterface*> m_interfaces;
     JoystickVector                   m_joysticks;
     unsigned int                     m_nextJoystickIndex;
-    mutable PLATFORM::CMutex         m_interfacesMutex;
-    mutable PLATFORM::CMutex         m_joystickMutex;
+    mutable P8PLATFORM::CMutex         m_interfacesMutex;
+    mutable P8PLATFORM::CMutex         m_joystickMutex;
   };
 }

--- a/src/api/cocoa/JoystickInterfaceCocoa.h
+++ b/src/api/cocoa/JoystickInterfaceCocoa.h
@@ -21,7 +21,7 @@
 
 #include "api/IJoystickInterface.h"
 
-#include "platform/threads/mutex.h"
+#include "p8-platform/threads/mutex.h"
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/hid/IOHIDBase.h>
@@ -84,7 +84,7 @@ namespace JOYSTICK
     std::vector<IOHIDDeviceRef> m_discoveredDevices;
     std::vector<DeviceHandle>   m_registeredDevices;
 
-    PLATFORM::CMutex m_deviceDiscoveryMutex;
-    PLATFORM::CMutex m_deviceInputMutex;
+    P8PLATFORM::CMutex m_deviceDiscoveryMutex;
+    P8PLATFORM::CMutex m_deviceInputMutex;
   };
 }

--- a/src/api/xinput/XInputDLL.h
+++ b/src/api/xinput/XInputDLL.h
@@ -19,7 +19,7 @@
  */
 #pragma once
 
-#include "platform/threads/mutex.h"
+#include "p8-platform/threads/mutex.h"
 
 #include <string>
 #include <windows.h>
@@ -87,6 +87,6 @@ namespace JOYSTICK
     FnXInputGetState        m_getState;
     FnXInputSetState        m_setState;
     FnXInputGetCapabilities m_getCaps;
-    PLATFORM::CMutex        m_mutex;
+    P8PLATFORM::CMutex        m_mutex;
   };
 }

--- a/src/filesystem/DirectoryCache.cpp
+++ b/src/filesystem/DirectoryCache.cpp
@@ -20,7 +20,7 @@
 
 #include "DirectoryCache.h"
 
-#include "platform/util/timeutils.h"
+#include "p8-platform/util/timeutils.h"
 
 #include <algorithm>
 
@@ -66,7 +66,7 @@ bool CDirectoryCache::GetDirectory(const std::string& path, std::vector<ADDON::C
     const int64_t timestamp = record.first;
     const int64_t expires = timestamp + DIRECTORY_LIFETIME_MS;
 
-    if (expires <= PLATFORM::GetTimeMs())
+    if (expires <= P8PLATFORM::GetTimeMs())
     {
       items = record.second;
       return true;
@@ -106,6 +106,6 @@ void CDirectoryCache::UpdateDirectory(const std::string& path, const std::vector
     }
   }
 
-  timestamp = PLATFORM::GetTimeMs();
+  timestamp = P8PLATFORM::GetTimeMs();
   cachedItems = items;
 }

--- a/src/log/Log.cpp
+++ b/src/log/Log.cpp
@@ -27,13 +27,13 @@
 #include "LogSyslog.h"
 #endif
 
-#include "platform/threads/threads.h"
+#include "p8-platform/threads/threads.h"
 
 #include <stdarg.h>
 #include <stdio.h>
 
 using namespace JOYSTICK;
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 
 #define MAXSYSLOGBUF (256)
 
@@ -56,7 +56,7 @@ CLog::~CLog(void)
 
 bool CLog::SetType(SYS_LOG_TYPE type)
 {
-  PLATFORM::CLockObject lock(m_mutex);
+  P8PLATFORM::CLockObject lock(m_mutex);
   if (m_pipe && m_pipe->Type() == type)
     return true; // Already set
 
@@ -84,7 +84,7 @@ bool CLog::SetType(SYS_LOG_TYPE type)
 
 void CLog::SetPipe(ILog* pipe)
 {
-  PLATFORM::CLockObject lock(m_mutex);
+  P8PLATFORM::CLockObject lock(m_mutex);
 
   const SYS_LOG_TYPE newType = pipe   ? pipe->Type()   : SYS_LOG_TYPE_NULL;
   const SYS_LOG_TYPE oldType = m_pipe ? m_pipe->Type() : SYS_LOG_TYPE_NULL;
@@ -95,7 +95,7 @@ void CLog::SetPipe(ILog* pipe)
 
 void CLog::SetLevel(SYS_LOG_LEVEL level)
 {
-  PLATFORM::CLockObject lock(m_mutex);
+  P8PLATFORM::CLockObject lock(m_mutex);
 
   const SYS_LOG_LEVEL newLevel = level;
   const SYS_LOG_LEVEL oldLevel = m_level;
@@ -114,7 +114,7 @@ void CLog::Log(SYS_LOG_LEVEL level, const char* format, ...)
   vsnprintf(buf, MAXSYSLOGBUF - 1, fmt, ap);
   va_end(ap);
 
-  PLATFORM::CLockObject lock(m_mutex);
+  P8PLATFORM::CLockObject lock(m_mutex);
 
   if (level > m_level)
     return;

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -22,7 +22,7 @@
 
 #include "ILog.h"
 
-#include "platform/threads/mutex.h"
+#include "p8-platform/threads/mutex.h"
 
 #ifndef esyslog
 #define esyslog(...) JOYSTICK::CLog::Get().Log(SYS_LOG_ERROR, __VA_ARGS__)
@@ -61,6 +61,6 @@ namespace JOYSTICK
   private:
     ILog*            m_pipe;
     SYS_LOG_LEVEL    m_level;
-    PLATFORM::CMutex m_mutex;
+    P8PLATFORM::CMutex m_mutex;
   };
 }

--- a/src/log/LogConsole.cpp
+++ b/src/log/LogConsole.cpp
@@ -24,7 +24,7 @@
 #include <stdio.h>
 
 using namespace JOYSTICK;
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 
 void CLogConsole::Log(SYS_LOG_LEVEL level, const char* logline)
 {

--- a/src/log/LogConsole.h
+++ b/src/log/LogConsole.h
@@ -22,7 +22,7 @@
 
 #include "ILog.h"
 
-#include "platform/threads/mutex.h"
+#include "p8-platform/threads/mutex.h"
 
 namespace JOYSTICK
 {
@@ -35,6 +35,6 @@ namespace JOYSTICK
     virtual SYS_LOG_TYPE Type(void) const override { return SYS_LOG_TYPE_CONSOLE; }
 
   private:
-    PLATFORM::CMutex m_mutex;
+    P8PLATFORM::CMutex m_mutex;
   };
 }

--- a/src/storage/ButtonMap.cpp
+++ b/src/storage/ButtonMap.cpp
@@ -20,7 +20,7 @@
 
 #include "ButtonMap.h"
 
-#include "platform/util/timeutils.h"
+#include "p8-platform/util/timeutils.h"
 
 using namespace JOYSTICK;
 
@@ -66,7 +66,7 @@ bool CButtonMap::MapFeatures(const std::string& controllerId, const FeatureVecto
 
     if (Save())
     {
-      m_timestamp = PLATFORM::GetTimeMs();
+      m_timestamp = P8PLATFORM::GetTimeMs();
       return true;
     }
   }
@@ -77,7 +77,7 @@ bool CButtonMap::MapFeatures(const std::string& controllerId, const FeatureVecto
 bool CButtonMap::Refresh(void)
 {
   const int64_t expires = m_timestamp + RESOURCE_LIFETIME_MS;
-  const int64_t now = PLATFORM::GetTimeMs();
+  const int64_t now = P8PLATFORM::GetTimeMs();
 
   if (now >= expires)
   {

--- a/src/storage/JustABunchOfFiles.cpp
+++ b/src/storage/JustABunchOfFiles.cpp
@@ -28,7 +28,7 @@
 #include <algorithm>
 
 using namespace JOYSTICK;
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 
 #define FOLDER_DEPTH  1  // Recurse into max 1 subdirectories (provider)
 

--- a/src/storage/JustABunchOfFiles.h
+++ b/src/storage/JustABunchOfFiles.h
@@ -24,7 +24,7 @@
 #include "IDatabase.h"
 #include "filesystem/DirectoryCache.h"
 
-#include "platform/threads/mutex.h"
+#include "p8-platform/threads/mutex.h"
 
 #include <map>
 #include <string>
@@ -82,6 +82,6 @@ namespace JOYSTICK
     const bool        m_bReadWrite;
     CDirectoryCache   m_directoryCache;
     CResources        m_resources;
-    PLATFORM::CMutex  m_mutex;
+    P8PLATFORM::CMutex  m_mutex;
   };
 }


### PR DESCRIPTION
This fixes compilation after rename of platform to p8-platform in Pulse-Eight/platform#20.
I guess this breaks ABI and/or API, because of the namespace change.