### PR TITLE
extended XInput features

### DIFF
--- a/src/api/xinput/JoystickInterfaceXInput.h
+++ b/src/api/xinput/JoystickInterfaceXInput.h
@@ -19,7 +19,6 @@
  */
 #pragma once
 
-#include "XInputDLL.h"
 #include "api/IJoystickInterface.h"
 
 namespace JOYSTICK

--- a/src/api/xinput/XInputDLL.cpp
+++ b/src/api/xinput/XInputDLL.cpp
@@ -124,18 +124,41 @@ bool CXInputDLL::GetState(unsigned int controllerId, XINPUT_STATE_EX& state)
 
 bool CXInputDLL::SetState(unsigned int controllerId, XINPUT_VIBRATION& vibration)
 {
+  CLockObject lock(m_mutex);
+
   if (!m_setState)
     return false;
 
-  // TODO
-  return false;
+  DWORD result = m_setState(controllerId, &vibration);
+  if (result != ERROR_SUCCESS)
+  {
+    if (result == ERROR_DEVICE_NOT_CONNECTED)
+      dsyslog("No XInput devices on port %u", controllerId);
+    else
+      esyslog("Failed to set XInput state on port %u (result=%u)", controllerId, result);
+    return false;
+  }
+
+  return true;
 }
 
 bool CXInputDLL::GetCapabilities(unsigned int controllerId, XINPUT_CAPABILITIES& caps)
 {
+  CLockObject lock(m_mutex);
+
   if (!m_getCaps)
     return false;
 
-  // TODO
-  return false;
+  // currently no other value than XINPUT_FLAG_GAMEPAD is supported for the second parameter
+  DWORD result = m_getCaps(controllerId, XINPUT_FLAG_GAMEPAD, &caps);
+  if (result != ERROR_SUCCESS)
+  {
+    if (result == ERROR_DEVICE_NOT_CONNECTED)
+      dsyslog("No XInput devices on port %u", controllerId);
+    else
+      esyslog("Failed to get XInput capabilities on port %u (result=%u)", controllerId, result);
+    return false;
+  }
+
+  return true;
 }

--- a/src/api/xinput/XInputDLL.h
+++ b/src/api/xinput/XInputDLL.h
@@ -74,6 +74,8 @@ namespace JOYSTICK
     };
     bool GetBatteryInformation(unsigned int controllerId, BatteryDeviceType deviceType, XINPUT_BATTERY_INFORMATION& battery);
 
+    bool PowerOff(unsigned int controllerId);
+
   private:
     // Forward decl's for XInput API's we load dynamically and use if available
     // [in] Index of the gamer associated with the device
@@ -93,12 +95,16 @@ namespace JOYSTICK
     // [in] Device associated with this user index to be queried. Must be BATTERY_DEVTYPE_GAMEPAD or BATTERY_DEVTYPE_HEADSET.
     typedef DWORD (WINAPI* FnXInputGetBatteryInformation)(DWORD dwUserIndex, BYTE devType, XINPUT_BATTERY_INFORMATION *pBatteryInformation);
 
+    // [in] Index of the gamer associated with the device
+    typedef DWORD (WINAPI* FnXInputPowerOffController)(DWORD dwUserIndex);
+
     HMODULE m_dll;
     std::string m_strVersion;
     FnXInputGetState m_getState;
     FnXInputSetState m_setState;
     FnXInputGetCapabilities m_getCaps;
     FnXInputGetBatteryInformation m_getBatteryInfo;
+    FnXInputPowerOffController m_powerOff;
     P8PLATFORM::CMutex m_mutex;
   };
 }

--- a/src/api/xinput/XInputDLL.h
+++ b/src/api/xinput/XInputDLL.h
@@ -67,6 +67,13 @@ namespace JOYSTICK
     bool SetState(unsigned int controllerId, XINPUT_VIBRATION& vibration);
     bool GetCapabilities(unsigned int controllerId, XINPUT_CAPABILITIES& caps);
 
+    enum class BatteryDeviceType
+    {
+      Controller,
+      Headset
+    };
+    bool GetBatteryInformation(unsigned int controllerId, BatteryDeviceType deviceType, XINPUT_BATTERY_INFORMATION& battery);
+
   private:
     // Forward decl's for XInput API's we load dynamically and use if available
     // [in] Index of the gamer associated with the device
@@ -82,11 +89,16 @@ namespace JOYSTICK
     // [out] Receives the capabilities
     typedef DWORD (WINAPI* FnXInputGetCapabilities)(DWORD dwUserIndex, DWORD dwFlags, XINPUT_CAPABILITIES* pCapabilities);
 
-    HMODULE                 m_dll;
-    std::string             m_strVersion;
-    FnXInputGetState        m_getState;
-    FnXInputSetState        m_setState;
+    // [in] Index of the gamer associated with the device
+    // [in] Device associated with this user index to be queried. Must be BATTERY_DEVTYPE_GAMEPAD or BATTERY_DEVTYPE_HEADSET.
+    typedef DWORD (WINAPI* FnXInputGetBatteryInformation)(DWORD dwUserIndex, BYTE devType, XINPUT_BATTERY_INFORMATION *pBatteryInformation);
+
+    HMODULE m_dll;
+    std::string m_strVersion;
+    FnXInputGetState m_getState;
+    FnXInputSetState m_setState;
     FnXInputGetCapabilities m_getCaps;
-    P8PLATFORM::CMutex        m_mutex;
+    FnXInputGetBatteryInformation m_getBatteryInfo;
+    P8PLATFORM::CMutex m_mutex;
   };
 }


### PR DESCRIPTION
This PR implements some additional XInput features which are not used / supported yet by the joystick API in general but I've tested reading the capabilities and battery info and turning the controller off works as well.

I also noticed that through `GetCapabilities()` we can check the type of the controller and that might actually be a lot of different things like a wheel, a guitar, a drum kit and what not. So maybe in the future we may have to extend the implementation to be able to handle the different controller types differently.