### PR TITLE
[ios] - fixed compilation due to struct __stat64 issues

### DIFF
--- a/src/utils/CommonIncludes.h
+++ b/src/utils/CommonIncludes.h
@@ -20,9 +20,13 @@
 #pragma once
 
 // This must be #defined before libXBMC_addon.h to fix compile
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(TARGET_DARWIN)
   #include <sys/stat.h>
   #define __stat64 stat64
+#endif
+
+#if defined(TARGET_DARWIN)
+#include "posix/os-types.h"
 #endif
 
 #include "kodi/libXBMC_addon.h"


### PR DESCRIPTION
Well i have no clue what that stat64 didl does there - but in general we have all this stuff in p8-platform if i remember correct. Fact is - this is not good for darwin ;) (got an undefined struct __stat64 error during compilation)

I explicitly included that os-types.h for darwin only to fix compilation - other platform devs need to check if this is ok for them too and adapt accordingly.