### PR TITLE
[cmake] Rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include(CheckIncludeFiles)
 
 # --- Add-on Dependencies ------------------------------------------------------
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 

--- a/peripheral.joystick/addon.xml.in
+++ b/peripheral.joystick/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="peripheral.joystick"
-  version="1.0.1"
+  version="1.1.0"
   name="Joystick Support"
   provider-name="Team-Kodi">
   <requires>


### PR DESCRIPTION
Needed after https://github.com/xbmc/xbmc/pull/9750 goes in