### PR TITLE
Update to peripheral API v1.1.0: Add function to save button maps

### DIFF
--- a/peripheral.joystick/addon.xml.in
+++ b/peripheral.joystick/addon.xml.in
@@ -6,7 +6,7 @@
   provider-name="Team-Kodi">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="kodi.peripheral" version="1.0.22"/>
+    <import addon="kodi.peripheral" version="1.0.24"/>
   </requires>
   <extension
     point="kodi.peripheral"

--- a/peripheral.joystick/addon.xml.in
+++ b/peripheral.joystick/addon.xml.in
@@ -6,7 +6,7 @@
   provider-name="Team-Kodi">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="kodi.peripheral" version="1.0.24"/>
+    <import addon="kodi.peripheral" version="1.1.0"/>
   </requires>
   <extension
     point="kodi.peripheral"

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -275,6 +275,17 @@ PERIPHERAL_ERROR MapFeatures(const JOYSTICK_INFO* joystick, const char* controll
   return bSuccess ? PERIPHERAL_NO_ERROR : PERIPHERAL_ERROR_FAILED;
 }
 
+void SaveButtonMap(const JOYSTICK_INFO* joystick)
+{
+  if (joystick == nullptr)
+    return;
+
+  ADDON::Joystick addonJoystick(*joystick);
+
+  if (CStorageManager::Get().SaveButtonMap(addonJoystick));
+    PERIPHERAL->RefreshButtonMaps(addonJoystick.Name());
+}
+
 void ResetButtonMap(const JOYSTICK_INFO* joystick, const char* controller_id)
 {
   if (!joystick || !controller_id)

--- a/src/api/udev/JoystickInterfaceUdev.cpp
+++ b/src/api/udev/JoystickInterfaceUdev.cpp
@@ -118,12 +118,12 @@ bool CJoystickInterfaceUdev::ScanForJoysticks(JoystickVector& joysticks)
 const ButtonMap& CJoystickInterfaceUdev::GetButtonMap()
 {
   auto& dflt = m_buttonMap["game.controller.default"];
-  dflt[CJoystickUdev::MOTOR_STRONG].SetPrimitive(ADDON::DriverPrimitive::CreateMotor(CJoystickUdev::MOTOR_STRONG));
-  dflt[CJoystickUdev::MOTOR_WEAK].SetPrimitive(ADDON::DriverPrimitive::CreateMotor(CJoystickUdev::MOTOR_WEAK));
+  dflt[CJoystickUdev::MOTOR_STRONG].SetPrimitive(JOYSTICK_MOTOR_PRIMITIVE, ADDON::DriverPrimitive::CreateMotor(CJoystickUdev::MOTOR_STRONG));
+  dflt[CJoystickUdev::MOTOR_WEAK].SetPrimitive(JOYSTICK_MOTOR_PRIMITIVE, ADDON::DriverPrimitive::CreateMotor(CJoystickUdev::MOTOR_WEAK));
 
   auto& ps = m_buttonMap["game.controller.ps"];
-  ps[CJoystickUdev::MOTOR_STRONG].SetPrimitive(ADDON::DriverPrimitive::CreateMotor(CJoystickUdev::MOTOR_STRONG));
-  ps[CJoystickUdev::MOTOR_WEAK].SetPrimitive(ADDON::DriverPrimitive::CreateMotor(CJoystickUdev::MOTOR_WEAK));
+  ps[CJoystickUdev::MOTOR_STRONG].SetPrimitive(JOYSTICK_MOTOR_PRIMITIVE, ADDON::DriverPrimitive::CreateMotor(CJoystickUdev::MOTOR_STRONG));
+  ps[CJoystickUdev::MOTOR_WEAK].SetPrimitive(JOYSTICK_MOTOR_PRIMITIVE, ADDON::DriverPrimitive::CreateMotor(CJoystickUdev::MOTOR_WEAK));
 
   return m_buttonMap;
 }

--- a/src/buttonmapper/ControllerTransformer.cpp
+++ b/src/buttonmapper/ControllerTransformer.cpp
@@ -74,25 +74,26 @@ bool CControllerTransformer::AddControllerMap(const std::string& controllerFrom,
       {
         if (fromFeature.Type() == feature.Type())
         {
+          return fromFeature.Primitives() == feature.Primitives();
           switch (feature.Type())
           {
           case JOYSTICK_FEATURE_TYPE_SCALAR:
           case JOYSTICK_FEATURE_TYPE_MOTOR:
           {
-            return fromFeature.Primitive() == feature.Primitive();
+            return fromFeature.Primitive(JOYSTICK_SCALAR_PRIMITIVE) == feature.Primitive(JOYSTICK_SCALAR_PRIMITIVE);
           }
           case JOYSTICK_FEATURE_TYPE_ANALOG_STICK:
           {
-            return fromFeature.Up()    == feature.Up() &&
-                   fromFeature.Down()  == feature.Down() &&
-                   fromFeature.Right() == feature.Right() &&
-                   fromFeature.Left()  == feature.Left();
+            return fromFeature.Primitive(JOYSTICK_ANALOG_STICK_UP)    == feature.Primitive(JOYSTICK_ANALOG_STICK_UP) &&
+                   fromFeature.Primitive(JOYSTICK_ANALOG_STICK_DOWN)  == feature.Primitive(JOYSTICK_ANALOG_STICK_DOWN) &&
+                   fromFeature.Primitive(JOYSTICK_ANALOG_STICK_RIGHT) == feature.Primitive(JOYSTICK_ANALOG_STICK_RIGHT) &&
+                   fromFeature.Primitive(JOYSTICK_ANALOG_STICK_LEFT)  == feature.Primitive(JOYSTICK_ANALOG_STICK_LEFT);
           }
           case JOYSTICK_FEATURE_TYPE_ACCELEROMETER:
           {
-            return fromFeature.PositiveX() == feature.PositiveX() &&
-                   fromFeature.PositiveY() == feature.PositiveY() &&
-                   fromFeature.PositiveZ() == feature.PositiveZ();
+            return fromFeature.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_X) == feature.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_X) &&
+                   fromFeature.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Y) == feature.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Y) &&
+                   fromFeature.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Z) == feature.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Z);
           }
           default:
             break;

--- a/src/storage/ButtonMap.cpp
+++ b/src/storage/ButtonMap.cpp
@@ -85,12 +85,17 @@ bool CButtonMap::MapFeatures(const std::string& controllerId, const FeatureVecto
       {
         return lhs.Name() < rhs.Name();
       });
+  }
 
-    if (Save())
-    {
-      m_timestamp = P8PLATFORM::GetTimeMs();
-      return true;
-    }
+  return false;
+}
+
+bool CButtonMap::SaveButtonMap()
+{
+  if (Save())
+  {
+    m_timestamp = P8PLATFORM::GetTimeMs();
+    return true;
   }
 
   return false;
@@ -103,12 +108,7 @@ bool CButtonMap::ResetButtonMap(const std::string& controllerId)
   if (!features.empty())
   {
     features.clear();
-
-    if (Save())
-    {
-      m_timestamp = P8PLATFORM::GetTimeMs();
-      return true;
-    }
+    return SaveButtonMap();
   }
 
   return false;

--- a/src/storage/ButtonMap.cpp
+++ b/src/storage/ButtonMap.cpp
@@ -57,37 +57,29 @@ const ButtonMap& CButtonMap::GetButtonMap()
   return m_buttonMap;
 }
 
-bool CButtonMap::MapFeatures(const std::string& controllerId, const FeatureVector& features)
+void CButtonMap::MapFeatures(const std::string& controllerId, const FeatureVector& features)
 {
   FeatureVector& myFeatures = m_buttonMap[controllerId];
 
-  // TODO: Optimize case when features are unchanged
-  bool bChanged = true; // TODO
-
-  if (bChanged)
+  // Remove features with the same name
+  for (auto& newFeature : features)
   {
-    // Remove features with the same name
-    for (auto& newFeature : features)
-    {
-      myFeatures.erase(std::remove_if(myFeatures.begin(), myFeatures.end(),
-        [newFeature](const ADDON::JoystickFeature& feature)
-        {
-          return feature.Name() == newFeature.Name();
-        }), myFeatures.end());
-    }
-
-    myFeatures.insert(myFeatures.begin(), features.begin(), features.end());
-
-    Sanitize(controllerId, myFeatures);
-
-    std::sort(myFeatures.begin(), myFeatures.end(),
-      [](const ADDON::JoystickFeature& lhs, const ADDON::JoystickFeature& rhs)
+    myFeatures.erase(std::remove_if(myFeatures.begin(), myFeatures.end(),
+      [newFeature](const ADDON::JoystickFeature& feature)
       {
-        return lhs.Name() < rhs.Name();
-      });
+        return feature.Name() == newFeature.Name();
+      }), myFeatures.end());
   }
 
-  return false;
+  myFeatures.insert(myFeatures.begin(), features.begin(), features.end());
+
+  Sanitize(controllerId, myFeatures);
+
+  std::sort(myFeatures.begin(), myFeatures.end(),
+    [](const ADDON::JoystickFeature& lhs, const ADDON::JoystickFeature& rhs)
+    {
+      return lhs.Name() < rhs.Name();
+    });
 }
 
 bool CButtonMap::SaveButtonMap()

--- a/src/storage/ButtonMap.h
+++ b/src/storage/ButtonMap.h
@@ -46,6 +46,8 @@ namespace JOYSTICK
 
     bool MapFeatures(const std::string& controllerId, const FeatureVector& features);
 
+    bool SaveButtonMap();
+
     bool ResetButtonMap(const std::string& controllerId);
 
     bool Refresh(void);

--- a/src/storage/ButtonMap.h
+++ b/src/storage/ButtonMap.h
@@ -54,7 +54,7 @@ namespace JOYSTICK
     virtual bool Load(void) = 0;
     virtual bool Save(void) const = 0;
 
-    void Sanitize();
+    static void Sanitize(const std::string& controllerId, FeatureVector& features);
 
     const std::string m_strResourcePath;
     DevicePtr         m_device;

--- a/src/storage/ButtonMap.h
+++ b/src/storage/ButtonMap.h
@@ -44,7 +44,7 @@ namespace JOYSTICK
 
     void GetControllerMap(ControllerMap& controllerMap);
 
-    bool MapFeatures(const std::string& controllerId, const FeatureVector& features);
+    void MapFeatures(const std::string& controllerId, const FeatureVector& features);
 
     bool SaveButtonMap();
 

--- a/src/storage/IDatabase.h
+++ b/src/storage/IDatabase.h
@@ -61,6 +61,11 @@ namespace JOYSTICK
                              const FeatureVector& features) = 0;
 
     /*!
+     * \copydoc CStorageManager::SaveButtonMap()
+     */
+    virtual bool SaveButtonMap(const ADDON::Joystick& driverInfo) = 0;
+
+    /*!
      * \copydoc CStorageManager::ResetButtonMap()
      */
     virtual bool ResetButtonMap(const ADDON::Joystick& driverInfo,

--- a/src/storage/JustABunchOfFiles.cpp
+++ b/src/storage/JustABunchOfFiles.cpp
@@ -159,6 +159,23 @@ bool CJustABunchOfFiles::MapFeatures(const ADDON::Joystick& driverInfo,
   return false;
 }
 
+bool CJustABunchOfFiles::SaveButtonMap(const ADDON::Joystick& driverInfo)
+{
+  if (!m_bReadWrite)
+    return false;
+
+  CDevice device(driverInfo);
+
+  CLockObject lock(m_mutex);
+
+  CButtonMap* resource = m_resources.GetResource(device);
+
+  if (resource)
+    return resource->SaveButtonMap();
+
+  return false;
+}
+
 bool CJustABunchOfFiles::ResetButtonMap(const ADDON::Joystick& driverInfo, const std::string& controllerId)
 {
   if (!m_bReadWrite)
@@ -174,7 +191,6 @@ bool CJustABunchOfFiles::ResetButtonMap(const ADDON::Joystick& driverInfo, const
     return resource->ResetButtonMap(controllerId);
 
   return false;
-
 }
 
 void CJustABunchOfFiles::IndexDirectory(const std::string& path, unsigned int folderDepth)

--- a/src/storage/JustABunchOfFiles.cpp
+++ b/src/storage/JustABunchOfFiles.cpp
@@ -154,7 +154,10 @@ bool CJustABunchOfFiles::MapFeatures(const ADDON::Joystick& driverInfo,
   }
 
   if (resource)
-    return resource->MapFeatures(controllerId, features);
+  {
+    resource->MapFeatures(controllerId, features);
+    return true;
+  }
 
   return false;
 }

--- a/src/storage/JustABunchOfFiles.h
+++ b/src/storage/JustABunchOfFiles.h
@@ -70,6 +70,7 @@ namespace JOYSTICK
     virtual bool MapFeatures(const ADDON::Joystick& driverInfo,
                              const std::string& controllerId,
                              const FeatureVector& features) override;
+    virtual bool SaveButtonMap(const ADDON::Joystick& driverInfo) override;
     virtual bool ResetButtonMap(const ADDON::Joystick& driverInfo,
                                 const std::string& controllerId) override;
 

--- a/src/storage/StorageManager.cpp
+++ b/src/storage/StorageManager.cpp
@@ -134,6 +134,16 @@ bool CStorageManager::MapFeatures(const ADDON::Joystick& joystick,
   return bModified;
 }
 
+bool CStorageManager::SaveButtonMap(const ADDON::Joystick& joystick)
+{
+  bool bModified = false;
+
+  for (DatabaseVector::const_iterator it = m_databases.begin(); it != m_databases.end(); ++it)
+    bModified |= (*it)->SaveButtonMap(joystick);
+
+  return bModified;
+}
+
 bool CStorageManager::ResetButtonMap(const ADDON::Joystick& joystick, const std::string& strControllerId)
 {
   bool bModified = false;

--- a/src/storage/StorageManager.cpp
+++ b/src/storage/StorageManager.cpp
@@ -126,12 +126,12 @@ bool CStorageManager::MapFeatures(const ADDON::Joystick& joystick,
                                   const std::string& strControllerId,
                                   const FeatureVector& features)
 {
-  bool bModified = false;
+  bool bSuccess = false;
 
   for (DatabaseVector::const_iterator it = m_databases.begin(); it != m_databases.end(); ++it)
-    bModified |= (*it)->MapFeatures(joystick, strControllerId, features);
+    bSuccess |= (*it)->MapFeatures(joystick, strControllerId, features);
 
-  return bModified;
+  return bSuccess;
 }
 
 bool CStorageManager::SaveButtonMap(const ADDON::Joystick& joystick)

--- a/src/storage/StorageManager.h
+++ b/src/storage/StorageManager.h
@@ -93,6 +93,15 @@ namespace JOYSTICK
                      const FeatureVector& features);
 
     /*!
+     * \brief Save the button map for the specified device
+     *
+     * \param deviceName The name of the device to reset
+     *
+     * \return true if the underlying storage was modified, false otherwise
+     */
+    bool SaveButtonMap(const ADDON::Joystick& joystick);
+
+    /*!
      * \brief Reset the button map for the specified device and controller profile
      *
      * \param deviceName The name of the device to reset

--- a/src/storage/StorageManager.h
+++ b/src/storage/StorageManager.h
@@ -86,7 +86,7 @@ namespace JOYSTICK
      * \param controller_id The game controller profile being updated
      * \param features      The array of features and their driver primitives
      *
-     * \return true if features were updated in a storage backend
+     * \return true if features were mapped in a storage backend
      */
     bool MapFeatures(const ADDON::Joystick& joystick,
                      const std::string& strDeviceId,

--- a/src/storage/api/DatabaseJoystickAPI.cpp
+++ b/src/storage/api/DatabaseJoystickAPI.cpp
@@ -38,3 +38,8 @@ bool CDatabaseJoystickAPI::ResetButtonMap(const ADDON::Joystick& driverInfo, con
 {
   return false;
 }
+
+bool CDatabaseJoystickAPI::SaveButtonMap(const ADDON::Joystick& driverInfo)
+{
+  return false;
+}

--- a/src/storage/api/DatabaseJoystickAPI.h
+++ b/src/storage/api/DatabaseJoystickAPI.h
@@ -34,5 +34,6 @@ namespace JOYSTICK
     virtual const ButtonMap& GetButtonMap(const ADDON::Joystick& driverInfo) override;
     virtual bool MapFeatures(const ADDON::Joystick& driverInfo, const std::string& controllerId, const FeatureVector& features) override;
     virtual bool ResetButtonMap(const ADDON::Joystick& driverInfo, const std::string& controllerId) override;
+    virtual bool SaveButtonMap(const ADDON::Joystick& driverInfo) override;
   };
 }

--- a/src/storage/xml/ButtonMapXml.cpp
+++ b/src/storage/xml/ButtonMapXml.cpp
@@ -264,42 +264,42 @@ bool CButtonMapXml::Serialize(const FeatureVector& features, TiXmlElement* pElem
     {
       case JOYSTICK_FEATURE_TYPE_SCALAR:
       {
-        SerializePrimitive(featureElem, feature.Primitive());
+        SerializePrimitive(featureElem, feature.Primitive(JOYSTICK_SCALAR_PRIMITIVE));
 
         break;
       }
       case JOYSTICK_FEATURE_TYPE_ANALOG_STICK:
       {
-        if (!SerializePrimitiveTag(featureElem, feature.Up(), BUTTONMAP_XML_ELEM_UP))
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_ANALOG_STICK_UP), BUTTONMAP_XML_ELEM_UP))
           return false;
 
-        if (!SerializePrimitiveTag(featureElem, feature.Down(), BUTTONMAP_XML_ELEM_DOWN))
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_ANALOG_STICK_DOWN), BUTTONMAP_XML_ELEM_DOWN))
           return false;
 
-        if (!SerializePrimitiveTag(featureElem, feature.Right(), BUTTONMAP_XML_ELEM_RIGHT))
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_ANALOG_STICK_RIGHT), BUTTONMAP_XML_ELEM_RIGHT))
           return false;
 
-        if (!SerializePrimitiveTag(featureElem, feature.Left(), BUTTONMAP_XML_ELEM_LEFT))
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_ANALOG_STICK_LEFT), BUTTONMAP_XML_ELEM_LEFT))
           return false;
 
         break;
       }
       case JOYSTICK_FEATURE_TYPE_ACCELEROMETER:
       {
-        if (!SerializePrimitiveTag(featureElem, feature.PositiveX(), BUTTONMAP_XML_ELEM_POSITIVE_X))
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_X), BUTTONMAP_XML_ELEM_POSITIVE_X))
           return false;
 
-        if (!SerializePrimitiveTag(featureElem, feature.PositiveY(), BUTTONMAP_XML_ELEM_POSITIVE_Y))
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Y), BUTTONMAP_XML_ELEM_POSITIVE_Y))
           return false;
 
-        if (!SerializePrimitiveTag(featureElem, feature.PositiveZ(), BUTTONMAP_XML_ELEM_POSITIVE_Z))
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Z), BUTTONMAP_XML_ELEM_POSITIVE_Z))
           return false;
 
         break;
       }
       case JOYSTICK_FEATURE_TYPE_MOTOR:
       {
-        SerializePrimitive(featureElem, feature.Primitive());
+        SerializePrimitive(featureElem, feature.Primitive(JOYSTICK_MOTOR_PRIMITIVE));
 
         break;
       }
@@ -313,43 +313,13 @@ bool CButtonMapXml::Serialize(const FeatureVector& features, TiXmlElement* pElem
 
 bool CButtonMapXml::IsValid(const ADDON::JoystickFeature& feature)
 {
-  bool bIsValid = false;
+  auto itValid = std::find_if(feature.Primitives().begin(), feature.Primitives().end(),
+    [](const ADDON::DriverPrimitive& primitive)
+    {
+      return primitive.Type() != JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN;
+    });
 
-  switch (feature.Type())
-  {
-    case JOYSTICK_FEATURE_TYPE_SCALAR:
-    case JOYSTICK_FEATURE_TYPE_MOTOR:
-    {
-      if (feature.Primitive().Type() != JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN)
-        bIsValid = true;
-      break;
-    }
-    case JOYSTICK_FEATURE_TYPE_ANALOG_STICK:
-    {
-      if (feature.Up().Type() != JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN ||
-          feature.Down().Type() != JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN ||
-          feature.Right().Type() != JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN ||
-          feature.Left().Type() != JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN)
-      {
-        bIsValid = true;
-      }
-      break;
-    }
-    case JOYSTICK_FEATURE_TYPE_ACCELEROMETER:
-    {
-      if (feature.PositiveX().Type() != JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN ||
-          feature.PositiveY().Type() != JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN ||
-          feature.PositiveZ().Type() != JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN)
-      {
-        bIsValid = true;
-      }
-      break;
-    }
-    default:
-      break;
-  }
-
-  return bIsValid;
+  return itValid != feature.Primitives().end();
 }
 
 bool CButtonMapXml::SerializePrimitiveTag(TiXmlElement* pElement, const ADDON::DriverPrimitive& primitive, const char* tagName)
@@ -480,7 +450,7 @@ bool CButtonMapXml::Deserialize(const TiXmlElement* pElement, FeatureVector& fea
     {
       case JOYSTICK_FEATURE_TYPE_SCALAR:
       {
-        feature.SetPrimitive(primitive);
+        feature.SetPrimitive(JOYSTICK_SCALAR_PRIMITIVE, primitive);
         break;
       }
       case JOYSTICK_FEATURE_TYPE_ANALOG_STICK:
@@ -519,10 +489,10 @@ bool CButtonMapXml::Deserialize(const TiXmlElement* pElement, FeatureVector& fea
         if (!bSuccess)
           return false;
 
-        feature.SetUp(up);
-        feature.SetDown(down);
-        feature.SetRight(right);
-        feature.SetLeft(left);
+        feature.SetPrimitive(JOYSTICK_ANALOG_STICK_UP, up);
+        feature.SetPrimitive(JOYSTICK_ANALOG_STICK_DOWN, down);
+        feature.SetPrimitive(JOYSTICK_ANALOG_STICK_RIGHT, right);
+        feature.SetPrimitive(JOYSTICK_ANALOG_STICK_LEFT, left);
 
         break;
       }
@@ -555,9 +525,9 @@ bool CButtonMapXml::Deserialize(const TiXmlElement* pElement, FeatureVector& fea
         if (!bSuccess)
           return false;
 
-        feature.SetPositiveX(positiveX);
-        feature.SetPositiveY(positiveY);
-        feature.SetPositiveZ(positiveZ);
+        feature.SetPrimitive(JOYSTICK_ACCELEROMETER_POSITIVE_X, positiveX);
+        feature.SetPrimitive(JOYSTICK_ACCELEROMETER_POSITIVE_Y, positiveY);
+        feature.SetPrimitive(JOYSTICK_ACCELEROMETER_POSITIVE_Z, positiveZ);
 
         break;
       }

--- a/src/storage/xml/ButtonMapXml.cpp
+++ b/src/storage/xml/ButtonMapXml.cpp
@@ -387,7 +387,7 @@ bool CButtonMapXml::Deserialize(const TiXmlElement* pElement, FeatureVector& fea
     return false;
   }
 
-  while (pFeature)
+  for ( ; pFeature != nullptr; pFeature = pFeature->NextSiblingElement(BUTTONMAP_XML_ELEM_FEATURE))
   {
     const char* name = pFeature->Attribute(BUTTONMAP_XML_ATTR_FEATURE_NAME);
     if (!name)
@@ -396,6 +396,19 @@ bool CButtonMapXml::Deserialize(const TiXmlElement* pElement, FeatureVector& fea
       return false;
     }
     std::string strName(name);
+
+    // Check if the feature was already deserialized
+    auto it = std::find_if(features.begin(), features.end(),
+      [strName](const ADDON::JoystickFeature& feature)
+      {
+        return feature.Name() == strName;
+      });
+
+    if (it != features.end())
+    {
+      esyslog("Duplicate feature \"%s\" found, skipping", strName.c_str());
+      continue;
+    }
 
     const TiXmlElement* pUp = nullptr;
     const TiXmlElement* pDown = nullptr;
@@ -536,8 +549,6 @@ bool CButtonMapXml::Deserialize(const TiXmlElement* pElement, FeatureVector& fea
     }
 
     features.push_back(feature);
-
-    pFeature = pFeature->NextSiblingElement(BUTTONMAP_XML_ELEM_FEATURE);
   }
 
   return true;


### PR DESCRIPTION
This updates peripheral.joystick to add a separate API call to save button maps.

Corresponds to https://github.com/xbmc/xbmc/pull/10364