### PR TITLE
[Fix] Resource leak

### DIFF
--- a/src/api/directinput/JoystickDirectInput.cpp
+++ b/src/api/directinput/JoystickDirectInput.cpp
@@ -45,6 +45,11 @@ CJoystickDirectInput::CJoystickDirectInput(GUID                           device
   SetName(strName);
 }
 
+CJoystickDirectInput::~CJoystickDirectInput()
+{
+  SAFE_RELEASE(m_joystickDevice);
+}
+
 bool CJoystickDirectInput::Equals(const CJoystick* rhs) const
 {
   if (rhs == nullptr)

--- a/src/api/directinput/JoystickDirectInput.cpp
+++ b/src/api/directinput/JoystickDirectInput.cpp
@@ -47,6 +47,9 @@ CJoystickDirectInput::CJoystickDirectInput(GUID                           device
 
 CJoystickDirectInput::~CJoystickDirectInput()
 {
+  if (m_joystickDevice)
+    m_joystickDevice->Unacquire();
+
   SAFE_RELEASE(m_joystickDevice);
 }
 

--- a/src/api/directinput/JoystickDirectInput.h
+++ b/src/api/directinput/JoystickDirectInput.h
@@ -33,7 +33,7 @@ namespace JOYSTICK
                          LPDIRECTINPUTDEVICE8           joystickDevice,
                          const std::string&             strName);
 
-    virtual ~CJoystickDirectInput(void) { }
+    virtual ~CJoystickDirectInput(void);
 
     virtual bool Equals(const CJoystick* rhs) const override;
 

--- a/src/api/directinput/JoystickInterfaceDirectInput.cpp
+++ b/src/api/directinput/JoystickInterfaceDirectInput.cpp
@@ -142,6 +142,16 @@ BOOL CALLBACK CJoystickInterfaceDirectInput::EnumJoysticksCallback(const DIDEVIC
     return DIENUM_CONTINUE;
   }
 
+  // This will be done automatically when we're in the foreground but
+  // let's do it here to check that we can acquire it and that no other
+  // app has it in exclusive mode
+  hr = pJoystick->Acquire();
+  if (FAILED(hr))
+  {
+    esyslog("%s: Failed to acquire device on: %s", __FUNCTION__, pdidInstance->tszProductName);
+    return DIENUM_CONTINUE;
+  }
+
   const std::string strName = pdidInstance->tszProductName ? pdidInstance->tszProductName : "";
 
   context->AddScanResult(JoystickPtr(new CJoystickDirectInput(pdidInstance->guidInstance, pJoystick, strName)));


### PR DESCRIPTION
Trying to track down a crash in dinput8 I came across this and noticed we don't actually call Release on the input objects when we're done with them.

Not sure this solves the crash but at least we shouldn't be leaking resources anymore. Also added some extra safeguard around scanning for devices so that we ignore exclusive mode devices that we can't access anyway.

Also documentation says Acquire shall be called before calling Poll or basically anything else.