### PR TITLE
[FIX] Don't mark callback as __cdecl when

### DIFF
--- a/src/api/directinput/JoystickDirectInput.cpp
+++ b/src/api/directinput/JoystickDirectInput.cpp
@@ -35,6 +35,36 @@ using namespace JOYSTICK;
 #define JOY_POV_SW   (JOY_POVBACKWARD + JOY_POVLEFT) / 2
 #define JOY_POV_NW   (JOY_POVLEFT + JOY_POV_360) / 2
 
+//-----------------------------------------------------------------------------
+// Name: EnumObjectsCallback()
+// Desc: Callback function for enumerating objects (axes, buttons, POVs) on a
+//       joystick. This function enables user interface elements for objects
+//       that are found to exist, and scales axes min/max values.
+//-----------------------------------------------------------------------------
+static BOOL EnumObjectsCallback(LPCDIDEVICEOBJECTINSTANCE pdidoi, LPVOID pContext)
+{
+  LPDIRECTINPUTDEVICE8 pJoy = static_cast<LPDIRECTINPUTDEVICE8>(pContext);
+
+  // For axes that are returned, set the DIPROP_RANGE property for the
+  // enumerated axis in order to scale min/max values.
+  if (pdidoi->dwType & DIDFT_AXIS)
+  {
+    DIPROPRANGE diprg;
+    diprg.diph.dwSize = sizeof(DIPROPRANGE);
+    diprg.diph.dwHeaderSize = sizeof(DIPROPHEADER);
+    diprg.diph.dwHow = DIPH_BYID;
+    diprg.diph.dwObj = pdidoi->dwType; // Specify the enumerated axis
+    diprg.lMin = AXIS_MIN;
+    diprg.lMax = AXIS_MAX;
+
+    // Set the range for the axis
+    HRESULT hr = pJoy->SetProperty(DIPROP_RANGE, &diprg.diph);
+    if (FAILED(hr))
+      esyslog("%s : Failed to set property on %s", __FUNCTION__, pdidoi->tszName);
+  }
+  return DIENUM_CONTINUE;
+}
+
 CJoystickDirectInput::CJoystickDirectInput(GUID                           deviceGuid,
                                            LPDIRECTINPUTDEVICE8           joystickDevice,
                                            const std::string&             strName)
@@ -112,36 +142,6 @@ bool CJoystickDirectInput::Initialize(void)
   }
 
   return CJoystick::Initialize();
-}
-
-//-----------------------------------------------------------------------------
-// Name: EnumObjectsCallback()
-// Desc: Callback function for enumerating objects (axes, buttons, POVs) on a
-//       joystick. This function enables user interface elements for objects
-//       that are found to exist, and scales axes min/max values.
-//-----------------------------------------------------------------------------
-BOOL CALLBACK CJoystickDirectInput::EnumObjectsCallback(const DIDEVICEOBJECTINSTANCE* pdidoi, VOID* pContext)
-{
-  LPDIRECTINPUTDEVICE8 pJoy = static_cast<LPDIRECTINPUTDEVICE8>(pContext);
-
-  // For axes that are returned, set the DIPROP_RANGE property for the
-  // enumerated axis in order to scale min/max values.
-  if (pdidoi->dwType & DIDFT_AXIS)
-  {
-    DIPROPRANGE diprg;
-    diprg.diph.dwSize = sizeof(DIPROPRANGE);
-    diprg.diph.dwHeaderSize = sizeof(DIPROPHEADER);
-    diprg.diph.dwHow = DIPH_BYID;
-    diprg.diph.dwObj = pdidoi->dwType; // Specify the enumerated axis
-    diprg.lMin = AXIS_MIN;
-    diprg.lMax = AXIS_MAX;
-
-    // Set the range for the axis
-    HRESULT hr = pJoy->SetProperty(DIPROP_RANGE, &diprg.diph);
-    if (FAILED(hr))
-      esyslog("%s : Failed to set property on %s", __FUNCTION__, pdidoi->tszName);
-  }
-  return DIENUM_CONTINUE;
 }
 
 bool CJoystickDirectInput::ScanEvents(void)

--- a/src/api/directinput/JoystickDirectInput.h
+++ b/src/api/directinput/JoystickDirectInput.h
@@ -43,8 +43,6 @@ namespace JOYSTICK
     virtual bool ScanEvents(void) override;
 
   private:
-    static BOOL CALLBACK EnumObjectsCallback(const DIDEVICEOBJECTINSTANCE *pdidoi, VOID *pContext);
-
     GUID m_deviceGuid;
     LPDIRECTINPUTDEVICE8 m_joystickDevice;
   };

--- a/src/api/directinput/JoystickInterfaceDirectInput.h
+++ b/src/api/directinput/JoystickInterfaceDirectInput.h
@@ -43,7 +43,7 @@ namespace JOYSTICK
   private:
     bool InitializeDirectInput(void);
 
-    static BOOL CALLBACK EnumJoysticksCallback(const DIDEVICEINSTANCE *pdidInstance, VOID *pContext);
+    static BOOL EnumJoysticksCallback(const DIDEVICEINSTANCE *pdidInstance, VOID *pContext);
     static bool IsXInputDevice(const GUID *pGuidProductFromDirectInput);
     static HWND GetMainWindowHandle(void);
     static BOOL CALLBACK EnumWindowsCallback(HWND hnd, LPARAM lParam);


### PR DESCRIPTION
docs doesn't say anything about it

Also move callback out of class and hide it
in cpp file.

Setting this as __cdecl can cause stack corruption as the caller doesn't expect it.